### PR TITLE
Fix typo & update link to Wire writing guidelines

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -5,9 +5,9 @@ date: 2020-02-17
 order: 07
 ---
 
-This guide is based a variety of resources and experiences. Some specific resources that served as a source of inspiration:
+This guide is based on a variety of resources and experiences. Some specific resources that served as a source of inspiration:
 
 - [Mailchimp Content Style Guide](https://styleguide.mailchimp.com/)
 - [Shopify Polaris](https://polaris.shopify.com/)
-- [Wire brand guidelines](https://brand-http.wire.com/text/tone-of-voice)
+- [Wire writing guidelines](https://brand.wire.com/text/)
 - [Microcopy: The Complete Guide](https://www.microcopybook.com/)


### PR DESCRIPTION
👋 Hey Quinn,

Thanks for building this, sharing it with the world, and crediting our work at Wire. 🙏 

Circling back today, I noticed a minor typo on the [References](https://uxcopy.quinnkeast.com/references) page, and an internal development URL in the Wire link. 

I suggest we update that link to point to the main site, as the implementation details behind the scenes could change, just like the [deployment URLs](https://github.com/quinnkeast/product-language-framework/pull/2#issuecomment-1007358591) for your framework.

While we're at it, I think the top level of the writing guidelines at [brand.wire.com/text](https://brand.wire.com/text/) is a better entry point, as it provides a bit more context than deep-linking straight to the [Tone of voice](https://brand.wire.com/text/tone-of-voice/) section.

Thanks again for sharing your work,

Roger
